### PR TITLE
Handle bigint serialization in safeStringify

### DIFF
--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            September 21st 2020, 6:49:55 am
+                            October 14th 2020, 5:52:20 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            October 14th 2020, 5:52:20 pm
+                            October 14th 2020, 5:53:37 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/test/safe-stringify.spec.ts
+++ b/test/safe-stringify.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * @poppinss/utils
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import test from 'japa'
+import { safeStringify } from '../src/safeStringify'
+
+test.group('safeStringify', () => {
+	test('stringifies object', (assert) => {
+		assert.deepEqual(safeStringify({ a: 18, b: 4 }), '{"a":18,"b":4}')
+	})
+
+	test('stringifies object (replacer)', (assert) => {
+		const replacer = (_, value) => {
+			return typeof value === 'number' ? value + 1 : value
+		}
+
+		assert.deepEqual(safeStringify({ a: 18, b: 4 }, replacer), '{"a":19,"b":5}')
+	})
+
+	test('stringifies object removing circular reference', (assert) => {
+		const o: any = { a: 18, b: 4 }
+		o.o = o
+		assert.deepEqual(safeStringify(o), '{"a":18,"b":4}')
+	})
+
+	test('stringifies object with bigint', (assert) => {
+		assert.deepEqual(safeStringify({ a: BigInt(18), b: 4 }), '{"a":"18","b":4}')
+	})
+
+	test('stringifies object with bigint (replacer returns bigint)', (assert) => {
+		const replacer = (_, value) => {
+			return typeof value === 'bigint' ? value + BigInt(1) : value
+		}
+
+		assert.deepEqual(safeStringify({ a: BigInt(18), b: 4 }, replacer), '{"a":"19","b":4}')
+	})
+
+	test('stringifies object with bigint (replacer handles bigint)', (assert) => {
+		const replacer = (_, value) => {
+			return typeof value === 'bigint' ? `${value.toString()}n` : value
+		}
+
+		assert.deepEqual(safeStringify({ a: BigInt(18), b: 4 }, replacer), '{"a":"18n","b":4}')
+	})
+})


### PR DESCRIPTION
## Proposed changes
Handle bigint serialization in `safeStringify` so it is not throwing error when object with bigint values is serialized but instead return serialized bigint using `toString()` function.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/poppinss/utils/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments
- extended arguments to be compatible with `JSON.stringify`
```javascript
function safeStringify(value: any, replacer?: ReplacerFn, space?: string | number): string
```
- allow custom handling of bigints via `replacer` function and fallback to `toString()` function
- added missing tests for function
