### PR TITLE
feat(types): add Opaque type helper

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -40,3 +40,5 @@ export type Constructor = new (...args: any[]) => any
 export type NormalizeConstructor<T extends Constructor> = {
   new (...args: any[]): InstanceType<T>
 } & Omit<T, 'constructor'>
+
+export type Opaque<T, K> = T & { [' __opaque__']: K }


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the `Opaque` type helper.
It is used to generate a named type from a primitive type. This could be achieved using a ValueObject, but a ValueObject may be overkill for simple use cases.

For example:
```ts
export type UUID = Opaque<string, 'UUID'>

function acceptOnlyUuid(id: UUID) {}
```

[TS Playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcDyYCGBHArsAHgBUAaOAaQD44BeOIuAMjgG84BtAcjgH0eIseYH04BdAFwU4AXwBQspCjgBVZQEkAIrXSD8BAM4woASwB2AczKdVmzpXkAzXKYDGMYxFNxMLl8DAwaKYANojKuMYAJgAUUZI2GgCUrHKyLp6G3tqc3Jj6KuoaaRnwAEbZnPI+fgFBoeFR0ZiJstX+gSFhETGliUA)