### PR TITLE
Accept accentued chars

### DIFF
--- a/src/string/change_case.ts
+++ b/src/string/change_case.ts
@@ -13,7 +13,7 @@ import * as changeCase from 'case-anything'
 const NO_CASE_SPLIT_REGEXP = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g]
 
 // Remove all non-word characters.
-const NO_CASE_STRIP_REGEXP = /[^A-Z0-9]+/gi
+const NO_CASE_STRIP_REGEXP = /[^-'a-zA-ZÀ-ÖØ-öø-ÿ0-9]+/gi
 
 const SMALL_WORDS =
   /\b(?:an?d?|a[st]|because|but|by|en|for|i[fn]|neither|nor|o[fnr]|only|over|per|so|some|tha[tn]|the|to|up|upon|vs?\.?|versus|via|when|with|without|yet)\b/i


### PR DESCRIPTION
Hello :grin: !

## Issue

I opened an issue on the EdgeJS repo before understanding it's relative to a Poppinss method : [#151](https://github.com/edge-js/edge/issues/151)

If I run this bunch of code
```
sentenceCase('bon état')
sentenceCase('bon etat')
camelCase('bon état')
```
It output me
```
Bon tat
Bon etat
bonEtat
```

the `é` char is truncated. Same for the `à`char. 

### ❓ Type of change

- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Here a fix, adding all accentued letters to the regex, to stop losing them.

It resolve the issue

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [x ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

I'm not sure if documentation update is required in this case ?

Have a good day and thanks for your work :smiley: !
