### PR TITLE
fix: compose mixins

### DIFF
--- a/bin/test.ts
+++ b/bin/test.ts
@@ -15,11 +15,11 @@ import { processCLIArgs, configure, run } from '@japa/runner'
 |
 | Please consult japa.dev/runner-config for the config docs.
 */
-processCLIArgs(process.argv.slice(2)),
+;(processCLIArgs(process.argv.slice(2)),
   configure({
     files: ['tests/**/*.spec.(ts|js)'],
     plugins: [assert(), expectTypeOf()],
-  })
+  }))
 
 /*
 |--------------------------------------------------------------------------

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -51,6 +51,7 @@ export function compose<T extends Constructor, A, B, C, D, E, F>(
   mixinB: UnaryFunction<A, B>,
   mixinC: UnaryFunction<B, C>,
   mixinD: UnaryFunction<C, D>,
+  mixinE: UnaryFunction<D, E>,
   mixinF: UnaryFunction<E, F>
 ): F
 export function compose<T extends Constructor, A, B, C, D, E, F, G>(
@@ -59,6 +60,7 @@ export function compose<T extends Constructor, A, B, C, D, E, F, G>(
   mixinB: UnaryFunction<A, B>,
   mixinC: UnaryFunction<B, C>,
   mixinD: UnaryFunction<C, D>,
+  mixinE: UnaryFunction<D, E>,
   mixinF: UnaryFunction<E, F>,
   mixinG: UnaryFunction<F, G>
 ): G
@@ -68,6 +70,7 @@ export function compose<T extends Constructor, A, B, C, D, E, F, G, H>(
   mixinB: UnaryFunction<A, B>,
   mixinC: UnaryFunction<B, C>,
   mixinD: UnaryFunction<C, D>,
+  mixinE: UnaryFunction<D, E>,
   mixinF: UnaryFunction<E, F>,
   mixinG: UnaryFunction<F, G>,
   mixinH: UnaryFunction<G, H>
@@ -78,6 +81,7 @@ export function compose<T extends Constructor, A, B, C, D, E, F, G, H, I>(
   mixinB: UnaryFunction<A, B>,
   mixinC: UnaryFunction<B, C>,
   mixinD: UnaryFunction<C, D>,
+  mixinE: UnaryFunction<D, E>,
   mixinF: UnaryFunction<E, F>,
   mixinG: UnaryFunction<F, G>,
   mixinH: UnaryFunction<G, H>,


### PR DESCRIPTION
### 🔗 Linked issue

[#47](https://github.com/poppinss/utils/issues/47)

### ❓ Type of change

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a bug when using more than five mixins in compose would break the resulting type.

### 📝 Checklist

- [X] I have read the [contribution guide](https://github.com/poppinss/.github/blob/main/docs/CONTRIBUTING.md).
- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
