### PR TITLE
feat(imports-bag): add support for default type imports

### DIFF
--- a/src/imports_bag.ts
+++ b/src/imports_bag.ts
@@ -10,6 +10,7 @@
 export type ImportInfo = {
   source: string
   defaultImport?: string
+  defaultTypeImport?: string
   namedImports?: string[]
   typeImports?: string[]
 }
@@ -44,9 +45,19 @@ export class ImportsBag {
       parts.push(`import ${importParts.join(', ')} from '${imp.source}'`)
     }
 
-    // Type imports are always separate
-    if (imp.typeImports && imp.typeImports.length > 0) {
-      parts.push(`import type { ${imp.typeImports.join(', ')} } from '${imp.source}'`)
+    // Handle default type import with or without type imports
+    if (imp.defaultTypeImport || (imp.typeImports && imp.typeImports.length > 0)) {
+      const typeImportParts: string[] = []
+
+      if (imp.defaultTypeImport) {
+        typeImportParts.push(imp.defaultTypeImport)
+      }
+
+      if (imp.typeImports && imp.typeImports.length > 0) {
+        typeImportParts.push(`{ ${imp.typeImports.join(', ')} }`)
+      }
+
+      parts.push(`import type ${typeImportParts.join(', ')} from '${imp.source}'`)
     }
 
     return parts.join('\n')
@@ -64,6 +75,13 @@ export class ImportsBag {
        */
       if (importInfo.defaultImport) {
         existing.defaultImport = importInfo.defaultImport
+      }
+
+      /**
+       * Set default type import (replaces existing if present)
+       */
+      if (importInfo.defaultTypeImport) {
+        existing.defaultTypeImport = importInfo.defaultTypeImport
       }
 
       /**
@@ -89,6 +107,7 @@ export class ImportsBag {
       this.#imports.set(importInfo.source, {
         source: importInfo.source,
         defaultImport: importInfo.defaultImport,
+        defaultTypeImport: importInfo.defaultTypeImport,
         namedImports: importInfo.namedImports ? [...importInfo.namedImports] : undefined,
         typeImports: importInfo.typeImports ? [...importInfo.typeImports] : undefined,
       })
@@ -104,6 +123,7 @@ export class ImportsBag {
     return Array.from(this.#imports.values()).map((imp) => ({
       source: imp.source,
       defaultImport: imp.defaultImport,
+      defaultTypeImport: imp.defaultTypeImport,
       namedImports: imp.namedImports ? [...new Set(imp.namedImports)] : undefined,
       typeImports: imp.typeImports ? [...new Set(imp.typeImports)] : undefined,
     }))

--- a/tests/imports_bag.spec.ts
+++ b/tests/imports_bag.spec.ts
@@ -20,6 +20,7 @@ test.group('ImportsBag | add', () => {
     assert.deepEqual(imports[0], {
       source: 'lodash',
       defaultImport: undefined,
+      defaultTypeImport: undefined,
       namedImports: ['debounce'],
       typeImports: undefined,
     })
@@ -34,6 +35,7 @@ test.group('ImportsBag | add', () => {
     assert.deepEqual(imports[0], {
       source: 'express',
       defaultImport: undefined,
+      defaultTypeImport: undefined,
       namedImports: undefined,
       typeImports: ['Request'],
     })
@@ -52,6 +54,7 @@ test.group('ImportsBag | add', () => {
     assert.deepEqual(imports[0], {
       source: 'express',
       defaultImport: undefined,
+      defaultTypeImport: undefined,
       namedImports: ['Router'],
       typeImports: ['Request', 'Response'],
     })
@@ -66,6 +69,7 @@ test.group('ImportsBag | add', () => {
     assert.deepEqual(imports[0], {
       source: 'react',
       defaultImport: 'React',
+      defaultTypeImport: undefined,
       namedImports: undefined,
       typeImports: undefined,
     })
@@ -84,6 +88,7 @@ test.group('ImportsBag | add', () => {
     assert.deepEqual(imports[0], {
       source: 'react',
       defaultImport: 'React',
+      defaultTypeImport: undefined,
       namedImports: ['useState', 'useEffect'],
       typeImports: undefined,
     })
@@ -102,6 +107,7 @@ test.group('ImportsBag | add', () => {
     assert.deepEqual(imports[0], {
       source: 'react',
       defaultImport: 'React',
+      defaultTypeImport: undefined,
       namedImports: undefined,
       typeImports: ['FC', 'PropsWithChildren'],
     })
@@ -121,8 +127,43 @@ test.group('ImportsBag | add', () => {
     assert.deepEqual(imports[0], {
       source: 'react',
       defaultImport: 'React',
+      defaultTypeImport: undefined,
       namedImports: ['useState'],
       typeImports: ['FC'],
+    })
+  })
+
+  test('add a single default type import', ({ assert }) => {
+    const bag = new ImportsBag()
+    bag.add({ source: 'fastify', defaultTypeImport: 'Fastify' })
+
+    const imports = bag.toArray()
+    assert.lengthOf(imports, 1)
+    assert.deepEqual(imports[0], {
+      source: 'fastify',
+      defaultImport: undefined,
+      defaultTypeImport: 'Fastify',
+      namedImports: undefined,
+      typeImports: undefined,
+    })
+  })
+
+  test('add default type import with type imports', ({ assert }) => {
+    const bag = new ImportsBag()
+    bag.add({
+      source: 'fastify',
+      defaultTypeImport: 'Fastify',
+      typeImports: ['FastifyRequest', 'FastifyReply'],
+    })
+
+    const imports = bag.toArray()
+    assert.lengthOf(imports, 1)
+    assert.deepEqual(imports[0], {
+      source: 'fastify',
+      defaultImport: undefined,
+      defaultTypeImport: 'Fastify',
+      namedImports: undefined,
+      typeImports: ['FastifyRequest', 'FastifyReply'],
     })
   })
 
@@ -197,6 +238,7 @@ test.group('ImportsBag | deduplication', () => {
     assert.deepEqual(imports[0], {
       source: 'express',
       defaultImport: undefined,
+      defaultTypeImport: undefined,
       namedImports: ['Router'],
       typeImports: ['Request'],
     })
@@ -212,6 +254,7 @@ test.group('ImportsBag | deduplication', () => {
     assert.deepEqual(imports[0], {
       source: 'express',
       defaultImport: undefined,
+      defaultTypeImport: undefined,
       namedImports: ['Router'],
       typeImports: ['Request'],
     })
@@ -237,8 +280,35 @@ test.group('ImportsBag | deduplication', () => {
     assert.deepEqual(imports[0], {
       source: 'react',
       defaultImport: 'React',
+      defaultTypeImport: undefined,
       namedImports: ['useState'],
       typeImports: undefined,
+    })
+  })
+
+  test('replace default type import when adding to existing source', ({ assert }) => {
+    const bag = new ImportsBag()
+    bag.add({ source: 'fastify', defaultTypeImport: 'Fastify' })
+    bag.add({ source: 'fastify', defaultTypeImport: 'F' })
+
+    const imports = bag.toArray()
+    assert.lengthOf(imports, 1)
+    assert.equal(imports[0].defaultTypeImport, 'F')
+  })
+
+  test('add default type import to existing source with type imports', ({ assert }) => {
+    const bag = new ImportsBag()
+    bag.add({ source: 'fastify', typeImports: ['FastifyRequest'] })
+    bag.add({ source: 'fastify', defaultTypeImport: 'Fastify' })
+
+    const imports = bag.toArray()
+    assert.lengthOf(imports, 1)
+    assert.deepEqual(imports[0], {
+      source: 'fastify',
+      defaultImport: undefined,
+      defaultTypeImport: 'Fastify',
+      namedImports: undefined,
+      typeImports: ['FastifyRequest'],
     })
   })
 })
@@ -378,5 +448,26 @@ test.group('ImportsBag | toString', () => {
     ].join('\n')
 
     assert.equal(bag.toString(), expected)
+  })
+
+  test('generate import statement for default type import', ({ assert }) => {
+    const bag = new ImportsBag()
+    bag.add({ source: 'fastify', defaultTypeImport: 'Fastify' })
+
+    assert.equal(bag.toString(), "import type Fastify from 'fastify'")
+  })
+
+  test('generate import statement for default type import with type imports', ({ assert }) => {
+    const bag = new ImportsBag()
+    bag.add({
+      source: 'fastify',
+      defaultTypeImport: 'Fastify',
+      typeImports: ['FastifyRequest', 'FastifyReply'],
+    })
+
+    assert.equal(
+      bag.toString(),
+      "import type Fastify, { FastifyRequest, FastifyReply } from 'fastify'"
+    )
   })
 })


### PR DESCRIPTION
Hey! 👋🏻 

This adds support for `defaultTypeImport` to generate `import type Foo from 'source'`.
Previously we could do:

- `defaultImport` → `import Foo from 'source'`
- `typeImports` → `import type { Foo } from 'source'`

But there was no way to do a default import as a type. Now you can:

```ts
bag.add({ source: 'fastify', defaultTypeImport: 'Fastify' })
// → import type Fastify from 'fastify'

bag.add({ 
  source: 'fastify', 
  defaultTypeImport: 'Fastify',
  typeImports: ['FastifyRequest', 'FastifyReply'] 
})
// → import type Fastify, { FastifyRequest, FastifyReply } from 'fastify'
```

Follows the same pattern as defaultImport + namedImports for consistency.