### PR TITLE
fix: fsReadAll filters out all files when the root absolute path contains a dot-prefixed directory

### DIFF
--- a/modules/fs/fs_read_all.ts
+++ b/modules/fs/fs_read_all.ts
@@ -66,10 +66,12 @@ export async function fsReadAll(
         return false
       }
 
-      if (
-        dirent.name.startsWith('.') ||
-        dirent.parentPath.split(sep).some((segment) => segment.startsWith('.'))
-      ) {
+      if (dirent.name.startsWith('.')) {
+        return false
+      }
+
+      const relativePath = relative(normalizedLocation, dirent.parentPath)
+      if (relativePath && relativePath.split(sep).some((segment) => segment.startsWith('.'))) {
         return false
       }
 

--- a/tests/fs_import_all.spec.ts
+++ b/tests/fs_import_all.spec.ts
@@ -149,6 +149,20 @@ test.group('importAll', (group) => {
     })
   })
 
+  test('should not filter files when the root absolute path contains a dot directory', async ({
+    assert,
+  }) => {
+    const dotParentPath = join(BASE_PATH, '.hidden-parent', 'project', 'config')
+    await outputFile(join(dotParentPath, 'app.ts'), 'export default { loaded: true }')
+    await outputFile(join(dotParentPath, 'logger.ts'), 'export default { enabled: true }')
+
+    const collection = await fsImportAll(dotParentPath)
+    assert.deepEqual(collection, {
+      app: { loaded: true },
+      logger: { enabled: true },
+    })
+  })
+
   test('define key name for the file', async ({ assert }) => {
     await outputFile(join(BASE_PATH, 'foo/bar/main.json'), '{ "loaded": true }')
 

--- a/tests/fs_read_all.spec.ts
+++ b/tests/fs_read_all.spec.ts
@@ -78,6 +78,18 @@ test.group('FS read all | relative paths', (group) => {
     )
   })
 
+  test('should not filter files when the root absolute path contains a dot directory', async ({
+    assert,
+  }) => {
+    const dotParentPath = join(BASE_PATH, '.hidden-parent', 'project', 'config')
+    await outputFile(join(dotParentPath, 'app.ts'), '')
+    await outputFile(join(dotParentPath, 'logger.ts'), '')
+
+    const files = await fsReadAll(dotParentPath)
+
+    assert.deepEqual(files, ['app.ts', 'logger.ts'].map(normalize))
+  })
+
   test('apply filter to ignore certain files', async ({ assert, expectTypeOf }) => {
     await outputFile(join(BASE_PATH, 'app.ts'), '')
     await outputFile(join(BASE_PATH, '.gitignore'), '')


### PR DESCRIPTION
`fsReadAll` (and by extension `fsImportAll`) silently returns an empty result when the scanned directory's absolute path contains a segment starting with `.` (e.g. .config, .claude, .local).

This happens because the dot-directory filter checks every segment of `dirent.parentPath`, which is the full absolute path, not just the path relative to the scanned directory:

`dirent.parentPath.split(sep).some((segment) => segment.startsWith('.'))`

For example, scanning `/home/user/my-project/.claude/worktrees/my-project/config/` causes every file to be filtered out because `.claude` is in the absolute path